### PR TITLE
Include persister to core

### DIFF
--- a/cli/States/EditSystemStates/AddSubtaskState.cpp
+++ b/cli/States/EditSystemStates/AddSubtaskState.cpp
@@ -15,9 +15,12 @@ StateOperationResult AddSubtaskState::Do(const std::shared_ptr<Context>& context
                                                            context,
                                                            io);
   addTaskMachine->Execute();
-  auto result = context->taskService_.AddSubtask(context->buffer_.id,
-                                                 TaskServiceDTO::TaskServiceDTO(context->buffer_.name, context->buffer_.label,
-                                                                                context->buffer_.priority, context->buffer_.date));
+  auto task = TaskServiceDTO::Create(context->buffer_.name, context->buffer_.label,
+                         context->buffer_.priority, context->buffer_.date);
+  if (!task.has_value()){
+    return StateOperationResult::FAIL;
+  }
+  auto result = context->taskService_.AddSubtask(context->buffer_.id, task.value());
 
   if (result.success_){
     std::string success {"Subtask was added.\n"} ;

--- a/cli/States/EditSystemStates/AddTaskState.cpp
+++ b/cli/States/EditSystemStates/AddTaskState.cpp
@@ -16,8 +16,13 @@ StateOperationResult AddTaskState::Do(const std::shared_ptr<Context>& context, I
                                                            io);
   addTaskMachine->Execute();
 
-  auto result = context->taskService_.AddTask(TaskServiceDTO::TaskServiceDTO(context->buffer_.name, context->buffer_.label,
-                                                                             context->buffer_.priority, context->buffer_.date));
+
+  auto task = TaskServiceDTO::Create(context->buffer_.name, context->buffer_.label,
+                                     context->buffer_.priority, context->buffer_.date);
+  if (!task.has_value()){
+    return StateOperationResult::FAIL;
+  }
+  auto result = context->taskService_.AddTask(task.value());
 
   if (result.success_){
     std::string success {"Task was added.\n"};

--- a/cli/States/InputStates/InputIDState.cpp
+++ b/cli/States/InputStates/InputIDState.cpp
@@ -31,6 +31,6 @@ StateOperationResult InputIDState::Do(const std::shared_ptr<Context>& context, I
     return StateOperationResult::INCORRECT_INPUT;
   }
 
-  context->buffer_.id = context->tasks_[id].GetID().Get();
+  context->buffer_.id = context->tasks_[id].GetTaskId().Get();
   return StateOperationResult::SUCCESS;
 }

--- a/core/API/TaskService.h
+++ b/core/API/TaskService.h
@@ -41,6 +41,20 @@ class TaskService{
  */
   virtual AddTaskResult             AddSubtask(const TaskID& rootTaskID, const TaskServiceDTO& subtask) = 0;
 
+/*
+ * Load all task to the system.
+ *
+ * @return-type: true if success, false if not.
+ */
+  virtual bool                      Load() = 0;
+
+/*
+ * Save all task of the system.
+ *
+ * @return-type: true if success, false if not.
+ */
+  virtual bool                      Save() = 0;
+
   /*
   *  Remove Task from the system.
   *

--- a/core/API/TaskServiceClass.cpp
+++ b/core/API/TaskServiceClass.cpp
@@ -22,6 +22,13 @@ bool TaskServiceClass::RemoveTask(const TaskID& ID){
   return result;
 }
 
+bool TaskServiceClass::Save() {
+  return repositoryController_->Save();
+}
+
+bool TaskServiceClass::Load() {
+  return repositoryController_->Load();
+}
 
 bool TaskServiceClass::PostponeTask(const TaskID& ID, const Date& date){
   return repositoryController_->Get()->PostponeTask(ID, date);

--- a/core/API/TaskServiceClass.cpp
+++ b/core/API/TaskServiceClass.cpp
@@ -6,23 +6,13 @@
 #include <string>
 #include <vector>
 
-TaskServiceClass TaskServiceClass::Create(){
-  return TaskServiceClass(std::move(std::make_unique<TaskRepositoryClass>(std::move(std::make_unique<TaskViewClass>()),
-                                                                          std::move(std::make_unique<TaskStorageClass>()))));
-}
-
-TaskServiceClass::TaskServiceClass(std::unique_ptr<TaskRepository> taskRepository)
-  : tasksRepository_(std::move(taskRepository)) {
-
-}
-
 AddTaskResult TaskServiceClass::AddTask(const TaskServiceDTO& task){
-  AddTaskResult addNewTask = tasksRepository_->AddTask(MakeTaskRepositoryDTO(task));
+  AddTaskResult addNewTask = tasksRepository_->AddTask(TaskServiceUtils::MakeTaskRepositoryDTO(task));
   return addNewTask;
 }
 
 AddTaskResult TaskServiceClass::AddSubtask(const TaskID& rootTaskID, const TaskServiceDTO& subtask){
-  auto dtoSubtask = MakeTaskRepositoryDTO(subtask);
+  auto dtoSubtask = TaskServiceUtils::MakeTaskRepositoryDTO(subtask);
   auto addNewSubtask = tasksRepository_->AddSubtask(rootTaskID, dtoSubtask);
   return addNewSubtask;
 }
@@ -46,62 +36,42 @@ std::optional<TaskServiceDTO> TaskServiceClass::GetTask(const TaskID& id) const{
   if (!task.has_value()){
     return std::nullopt;
   }
-  return MakeTaskDTO(task.value());
+  return TaskServiceUtils::MakeTaskDTO(task.value());
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetSubtask(const TaskID& id) const{
   auto subtasks = tasksRepository_->GetSubtask(id);
-  return MakeTasksDTO(subtasks);
+  return TaskServiceUtils::MakeTasksDTO(subtasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasks(bool byPriority) const{
   auto tasks = tasksRepository_->GetTasks();
-  return MakeTasksDTO(tasks);
+  return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTodayTasks(bool byPriority) const{
   auto tasks = tasksRepository_->GetTodayTasks(byPriority);
-  return MakeTasksDTO(tasks);
+  return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetWeekTasks(bool byPriority) const{
   auto tasks = tasksRepository_->GetWeekTasks(byPriority);
-  return MakeTasksDTO(tasks);
+  return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasksByLabel(const std::string& label, bool byPriority) const{
   auto tasks = tasksRepository_->GetTasksByLabel(label, byPriority);
-  return MakeTasksDTO(tasks);
+  return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasksByName(const std::string& name, bool byPriority) const{
   auto tasks = tasksRepository_->GetTasksByName(name, byPriority);
-  return MakeTasksDTO(tasks);
+  return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasksByPriority(const Priority& priority) const{
   auto tasks = tasksRepository_->GetTasksByPriority(priority);
-  return MakeTasksDTO(tasks);
+  return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
-TaskServiceDTO TaskServiceClass::MakeTaskDTO(const TaskRepositoryDTO& task) const {
-  auto newTask = TaskServiceDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate(),
-                                     task.Complete(), task.GetID());
-  assert(newTask.has_value());
-  return newTask.value();
-}
-
-std::vector<TaskServiceDTO> TaskServiceClass::MakeTasksDTO(const std::vector<TaskRepositoryDTO> &tasksForDTO) const {
-  std::vector<TaskServiceDTO> result;
-  for (const auto& task : tasksForDTO){
-    result.push_back(MakeTaskDTO(task));
-  }
-  return result;
-}
-
-TaskRepositoryDTO TaskServiceClass::MakeTaskRepositoryDTO(const TaskServiceDTO &task) const {
-  auto newTask =  TaskRepositoryDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate());
-  assert(newTask.has_value());
-  return newTask.value();
-}
 

--- a/core/API/TaskServiceClass.cpp
+++ b/core/API/TaskServiceClass.cpp
@@ -7,32 +7,32 @@
 #include <vector>
 
 AddTaskResult TaskServiceClass::AddTask(const TaskServiceDTO& task){
-  AddTaskResult addNewTask = tasksRepository_->AddTask(TaskServiceUtils::MakeTaskRepositoryDTO(task));
+  AddTaskResult addNewTask = repositoryController_->Get()->AddTask(TaskServiceUtils::MakeTaskRepositoryDTO(task));
   return addNewTask;
 }
 
 AddTaskResult TaskServiceClass::AddSubtask(const TaskID& rootTaskID, const TaskServiceDTO& subtask){
   auto dtoSubtask = TaskServiceUtils::MakeTaskRepositoryDTO(subtask);
-  auto addNewSubtask = tasksRepository_->AddSubtask(rootTaskID, dtoSubtask);
+  auto addNewSubtask = repositoryController_->Get()->AddSubtask(rootTaskID, dtoSubtask);
   return addNewSubtask;
 }
 
 bool TaskServiceClass::RemoveTask(const TaskID& ID){
-  auto result = tasksRepository_->RemoveTask(ID);
+  auto result = repositoryController_->Get()->RemoveTask(ID);
   return result;
 }
 
 
 bool TaskServiceClass::PostponeTask(const TaskID& ID, const Date& date){
-  return tasksRepository_->PostponeTask(ID, date);
+  return repositoryController_->Get()->PostponeTask(ID, date);
 }
 
 bool TaskServiceClass::SetTaskComplete(const TaskID &ID) {
-  return tasksRepository_->SetTaskComplete(ID);
+  return repositoryController_->Get()->SetTaskComplete(ID);
 }
 
 std::optional<TaskServiceDTO> TaskServiceClass::GetTask(const TaskID& id) const{
-  auto task = tasksRepository_->GetTask(id);
+  auto task = repositoryController_->Get()->GetTask(id);
   if (!task.has_value()){
     return std::nullopt;
   }
@@ -40,37 +40,37 @@ std::optional<TaskServiceDTO> TaskServiceClass::GetTask(const TaskID& id) const{
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetSubtask(const TaskID& id) const{
-  auto subtasks = tasksRepository_->GetSubtask(id);
+  auto subtasks = repositoryController_->Get()->GetSubtask(id);
   return TaskServiceUtils::MakeTasksDTO(subtasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasks(bool byPriority) const{
-  auto tasks = tasksRepository_->GetTasks();
+  auto tasks = repositoryController_->Get()->GetTasks();
   return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTodayTasks(bool byPriority) const{
-  auto tasks = tasksRepository_->GetTodayTasks(byPriority);
+  auto tasks = repositoryController_->Get()->GetTodayTasks(byPriority);
   return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetWeekTasks(bool byPriority) const{
-  auto tasks = tasksRepository_->GetWeekTasks(byPriority);
+  auto tasks = repositoryController_->Get()->GetWeekTasks(byPriority);
   return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasksByLabel(const std::string& label, bool byPriority) const{
-  auto tasks = tasksRepository_->GetTasksByLabel(label, byPriority);
+  auto tasks = repositoryController_->Get()->GetTasksByLabel(label, byPriority);
   return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasksByName(const std::string& name, bool byPriority) const{
-  auto tasks = tasksRepository_->GetTasksByName(name, byPriority);
+  auto tasks = repositoryController_->Get()->GetTasksByName(name, byPriority);
   return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 
 std::vector<TaskServiceDTO> TaskServiceClass::GetTasksByPriority(const Priority& priority) const{
-  auto tasks = tasksRepository_->GetTasksByPriority(priority);
+  auto tasks = repositoryController_->Get()->GetTasksByPriority(priority);
   return TaskServiceUtils::MakeTasksDTO(tasks);
 }
 

--- a/core/API/TaskServiceClass.h
+++ b/core/API/TaskServiceClass.h
@@ -6,8 +6,7 @@
 #define TASKMANAGER_SRC_TASKSERVICE_H_
 #include "TaskService.h"
 #include "TaskServiceUtils.h"
-#include "Memory_Model/Storage/TaskRepositoryClass.h"
-
+#include "Memory_Model/Storage/TaskRepositoryController.h"
 /*
  *  Enter point to the program.
  *
@@ -17,10 +16,8 @@
  */
 class TaskServiceClass : public TaskService {
  public:
-  TaskServiceClass(std::function<std::unique_ptr<TaskRepository>()> repositoryFactory)
-    : repositoryFactory_(repositoryFactory)  {
-    tasksRepository_ = std::move(repositoryFactory_());
-  }
+  TaskServiceClass(const std::function<std::unique_ptr<TaskRepository>()>& repositoryFactory)
+    : repositoryController_(std::move(std::make_unique<TaskRepositoryController>(repositoryFactory))) { }
 
  public:
   AddTaskResult                    AddTask(const TaskServiceDTO& task) override;
@@ -42,8 +39,7 @@ class TaskServiceClass : public TaskService {
   std::vector<TaskServiceDTO>      GetTasksByPriority(const Priority& priority) const override;
 
  private:
-  std::unique_ptr<TaskRepository>                   tasksRepository_;
-  std::function<std::unique_ptr<TaskRepository>()>  repositoryFactory_;
+  std::unique_ptr<TaskRepositoryController> repositoryController_;
 };
 
 #endif //TASKMANAGER_SRC_TASKSERVICE_H_

--- a/core/API/TaskServiceClass.h
+++ b/core/API/TaskServiceClass.h
@@ -5,6 +5,7 @@
 #ifndef TASKMANAGER_SRC_TASKSERVICE_H_
 #define TASKMANAGER_SRC_TASKSERVICE_H_
 #include "TaskService.h"
+#include "TaskServiceUtils.h"
 #include "Memory_Model/Storage/TaskRepositoryClass.h"
 
 /*
@@ -16,17 +17,19 @@
  */
 class TaskServiceClass : public TaskService {
  public:
-  static TaskServiceClass Create();
- public:
+  TaskServiceClass(std::function<std::unique_ptr<TaskRepository>()> repositoryFactory) {
+    tasksRepository_ = std::move(repositoryFactory());
+  }
 
+ public:
   AddTaskResult                    AddTask(const TaskServiceDTO& task) override;
   AddTaskResult                    AddSubtask(const TaskID& rootTaskID, const TaskServiceDTO& subtask) override;
   bool                             RemoveTask(const TaskID& ID) override;
   bool                             PostponeTask(const TaskID& ID, const Date& date) override;
+
   bool                             SetTaskComplete(const TaskID& ID) override;
 
  public:
-
   std::optional<TaskServiceDTO>    GetTask(const TaskID& id) const override;
   std::vector<TaskServiceDTO>      GetSubtask(const TaskID& id) const override;
   std::vector<TaskServiceDTO>      GetTasks(bool byPriority) const override;
@@ -34,42 +37,12 @@ class TaskServiceClass : public TaskService {
   std::vector<TaskServiceDTO>      GetWeekTasks(bool byPriority) const override;
   std::vector<TaskServiceDTO>      GetTasksByLabel(const std::string& label, bool byPriority) const override;
   std::vector<TaskServiceDTO>      GetTasksByName(const std::string& name, bool byPriority) const override;
+
   std::vector<TaskServiceDTO>      GetTasksByPriority(const Priority& priority) const override;
 
  private:
+  std::unique_ptr<TaskRepository>  tasksRepository_;
 
-  std::unique_ptr<TaskRepository>            tasksRepository_;
-
-  TaskServiceClass(std::unique_ptr<TaskRepository> taskRepository);
-
- private:
-
-/*
- * Converts from vector of TaskRepositoryDTO to vector of TaskServiceDTO
- *
- * @param: std::vector of TaskRepositoryDTO
- *
- * @return-type: std::vector of TaskServiceDTO
- */
-  std::vector<TaskServiceDTO>      MakeTasksDTO(const std::vector<TaskRepositoryDTO>& tasksForDTO) const;
-
-/*
- * Converts from TaskRepositoryDTO to vector of TaskServiceDTO
- *
- * @param: TaskRepositoryDTO
- *
- * @return-type: std::vector of TaskServiceDTO
- */
-  TaskServiceDTO                   MakeTaskDTO(const TaskRepositoryDTO& task) const;
-
-/*
- * Converts from TaskServiceDTO to vector of TaskRepositoryDTO
- *
- * @param: TaskServiceDTO
- *
- * @return-type: TaskRepositoryDTO
- */
-  TaskRepositoryDTO                   MakeTaskRepositoryDTO(const TaskServiceDTO& task) const;
 };
 
 #endif //TASKMANAGER_SRC_TASKSERVICE_H_

--- a/core/API/TaskServiceClass.h
+++ b/core/API/TaskServiceClass.h
@@ -24,6 +24,8 @@ class TaskServiceClass : public TaskService {
   AddTaskResult                    AddSubtask(const TaskID& rootTaskID, const TaskServiceDTO& subtask) override;
   bool                             RemoveTask(const TaskID& ID) override;
   bool                             PostponeTask(const TaskID& ID, const Date& date) override;
+  bool                             Save() override;
+  bool                             Load() override;
 
   bool                             SetTaskComplete(const TaskID& ID) override;
 

--- a/core/API/TaskServiceClass.h
+++ b/core/API/TaskServiceClass.h
@@ -17,8 +17,9 @@
  */
 class TaskServiceClass : public TaskService {
  public:
-  TaskServiceClass(std::function<std::unique_ptr<TaskRepository>()> repositoryFactory) {
-    tasksRepository_ = std::move(repositoryFactory());
+  TaskServiceClass(std::function<std::unique_ptr<TaskRepository>()> repositoryFactory)
+    : repositoryFactory_(repositoryFactory)  {
+    tasksRepository_ = std::move(repositoryFactory_());
   }
 
  public:
@@ -41,8 +42,8 @@ class TaskServiceClass : public TaskService {
   std::vector<TaskServiceDTO>      GetTasksByPriority(const Priority& priority) const override;
 
  private:
-  std::unique_ptr<TaskRepository>  tasksRepository_;
-
+  std::unique_ptr<TaskRepository>                   tasksRepository_;
+  std::function<std::unique_ptr<TaskRepository>()>  repositoryFactory_;
 };
 
 #endif //TASKMANAGER_SRC_TASKSERVICE_H_

--- a/core/API/TaskServiceUtils.cpp
+++ b/core/API/TaskServiceUtils.cpp
@@ -1,0 +1,37 @@
+//
+// Created by valeriisudakov on 01.10.20.
+//
+
+#include "TaskServiceUtils.h"
+#include "Memory_Model/Storage/TaskRepositoryClass.h"
+
+std::function<std::unique_ptr<TaskRepository>()> TaskServiceUtils::GetRepositoryFactory(){
+  auto factory = [](){
+    std::unique_ptr<TaskStorage> storage = std::make_unique<TaskStorageClass>();
+    std::unique_ptr<TaskView> view = std::make_unique<TaskViewClass>();
+    return std::move(std::make_unique<TaskRepositoryClass>(std::move(view), std::move(storage)));
+  };
+
+  return factory;
+}
+
+TaskServiceDTO TaskServiceUtils::MakeTaskDTO(const TaskRepositoryDTO& task) {
+  auto newTask = TaskServiceDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate(),
+                                        task.Complete(), task.GetID());
+  assert(newTask.has_value());
+  return newTask.value();
+}
+
+std::vector<TaskServiceDTO> TaskServiceUtils::MakeTasksDTO(const std::vector<TaskRepositoryDTO> &tasksForDTO) {
+  std::vector<TaskServiceDTO> result;
+  for (const auto& task : tasksForDTO){
+    result.push_back(MakeTaskDTO(task));
+  }
+  return result;
+}
+
+TaskRepositoryDTO TaskServiceUtils::MakeTaskRepositoryDTO(const TaskServiceDTO &task) {
+  auto newTask =  TaskRepositoryDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate());
+  assert(newTask.has_value());
+  return newTask.value();
+}

--- a/core/API/TaskServiceUtils.cpp
+++ b/core/API/TaskServiceUtils.cpp
@@ -15,23 +15,21 @@ std::function<std::unique_ptr<TaskRepository>()> TaskServiceUtils::GetRepository
   return factory;
 }
 
-TaskServiceDTO TaskServiceUtils::MakeTaskDTO(const TaskRepositoryDTO& task) {
+std::optional<TaskServiceDTO> TaskServiceUtils::MakeTaskDTO(const TaskRepositoryDTO& task) {
   auto newTask = TaskServiceDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate(),
                                         task.Complete(), task.GetID());
-  assert(newTask.has_value());
-  return newTask.value();
+  return newTask;
 }
 
 std::vector<TaskServiceDTO> TaskServiceUtils::MakeTasksDTO(const std::vector<TaskRepositoryDTO> &tasksForDTO) {
   std::vector<TaskServiceDTO> result;
   for (const auto& task : tasksForDTO){
-    result.push_back(MakeTaskDTO(task));
+    result.push_back(MakeTaskDTO(task).value());
   }
   return result;
 }
 
 TaskRepositoryDTO TaskServiceUtils::MakeTaskRepositoryDTO(const TaskServiceDTO &task) {
   auto newTask =  TaskRepositoryDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate());
-  assert(newTask.has_value());
   return newTask.value();
 }

--- a/core/API/TaskServiceUtils.h
+++ b/core/API/TaskServiceUtils.h
@@ -24,7 +24,7 @@ std::function<std::unique_ptr<TaskRepository>()> GetRepositoryFactory();
  *
  * @return-type: std::vector of TaskServiceDTO
  */
-std::vector<TaskServiceDTO>      MakeTasksDTO(const std::vector<TaskRepositoryDTO>& tasksForDTO);
+std::vector<TaskServiceDTO>         MakeTasksDTO(const std::vector<TaskRepositoryDTO>& tasksForDTO);
 
 /*
  * Converts from TaskRepositoryDTO to vector of TaskServiceDTO
@@ -33,7 +33,7 @@ std::vector<TaskServiceDTO>      MakeTasksDTO(const std::vector<TaskRepositoryDT
  *
  * @return-type: std::vector of TaskServiceDTO
  */
-TaskServiceDTO                   MakeTaskDTO(const TaskRepositoryDTO& task);
+std::optional<TaskServiceDTO>       MakeTaskDTO(const TaskRepositoryDTO& task);
 
 /*
  * Converts from TaskServiceDTO to vector of TaskRepositoryDTO

--- a/core/API/TaskServiceUtils.h
+++ b/core/API/TaskServiceUtils.h
@@ -1,0 +1,48 @@
+//
+// Created by valeriisudakov on 01.10.20.
+//
+
+#ifndef TASKMANAGER_CORE_API_TASKSERVICEUTILS_H_
+#define TASKMANAGER_CORE_API_TASKSERVICEUTILS_H_
+#include "TaskServiceDTO.h"
+#include "Memory_Model/Storage/TaskRepositoryDTO.h"
+
+class TaskRepository;
+
+namespace TaskServiceUtils {
+/*
+ *  Create and return pointer to factory-method of TaskRepository
+ *
+ *  @return-type: pointer to factory-method of TaskRepository
+ */
+std::function<std::unique_ptr<TaskRepository>()> GetRepositoryFactory();
+
+/*
+ * Converts from vector of TaskRepositoryDTO to vector of TaskServiceDTO
+ *
+ * @param: std::vector of TaskRepositoryDTO
+ *
+ * @return-type: std::vector of TaskServiceDTO
+ */
+std::vector<TaskServiceDTO>      MakeTasksDTO(const std::vector<TaskRepositoryDTO>& tasksForDTO);
+
+/*
+ * Converts from TaskRepositoryDTO to vector of TaskServiceDTO
+ *
+ * @param: TaskRepositoryDTO
+ *
+ * @return-type: std::vector of TaskServiceDTO
+ */
+TaskServiceDTO                   MakeTaskDTO(const TaskRepositoryDTO& task);
+
+/*
+ * Converts from TaskServiceDTO to vector of TaskRepositoryDTO
+ *
+ * @param: TaskServiceDTO
+ *
+ * @return-type: TaskRepositoryDTO
+ */
+TaskRepositoryDTO                   MakeTaskRepositoryDTO(const TaskServiceDTO& task);
+};
+
+#endif //TASKMANAGER_CORE_API_TASKSERVICEUTILS_H_

--- a/core/Memory_Model/Storage/TaskRepositoryController.cpp
+++ b/core/Memory_Model/Storage/TaskRepositoryController.cpp
@@ -19,7 +19,7 @@ bool TaskRepositoryController::Save() {
 }
 
 bool TaskRepositoryController::Load() {
-  std::fstream file("Tasks.txt", std::ios::out);
+  std::fstream file("Tasks.txt", std::ios::in);
   auto newRepository = repositoryFactory_();
   auto persister = PersisterUtils::CreatePersister(*newRepository, file);
   auto result = persister->Load();

--- a/core/Memory_Model/Storage/TaskRepositoryController.cpp
+++ b/core/Memory_Model/Storage/TaskRepositoryController.cpp
@@ -1,0 +1,9 @@
+//
+// Created by valeriisudakov on 03.10.20.
+//
+
+#include "TaskRepositoryController.h"
+
+const std::unique_ptr<TaskRepository>& TaskRepositoryController::Get() const {
+  return tasksRepository_;
+}

--- a/core/Memory_Model/Storage/TaskRepositoryController.cpp
+++ b/core/Memory_Model/Storage/TaskRepositoryController.cpp
@@ -3,7 +3,30 @@
 //
 
 #include "TaskRepositoryController.h"
+#include "Persister/TaskPersister.h"
+#include "Persister/TaskPersisterUtils.h"
 
 const std::unique_ptr<TaskRepository>& TaskRepositoryController::Get() const {
   return tasksRepository_;
+}
+
+bool TaskRepositoryController::Save() {
+  std::fstream file("Tasks.txt", std::ios::out);
+  auto persister = PersisterUtils::CreatePersister(*tasksRepository_, file);
+  auto result = persister->Save();
+  file.close();
+  return result;
+}
+
+bool TaskRepositoryController::Load() {
+  std::fstream file("Tasks.txt", std::ios::out);
+  auto newRepository = repositoryFactory_();
+  auto persister = PersisterUtils::CreatePersister(*newRepository, file);
+  auto result = persister->Load();
+
+  if (result){
+    std::swap(tasksRepository_, newRepository);
+  }
+  file.close();
+  return result;
 }

--- a/core/Memory_Model/Storage/TaskRepositoryController.h
+++ b/core/Memory_Model/Storage/TaskRepositoryController.h
@@ -15,7 +15,8 @@ class TaskRepositoryController {
 
  public:
   const std::unique_ptr<TaskRepository>&            Get() const;
-
+  bool                                              Save();
+  bool                                              Load();
  private:
   std::unique_ptr<TaskRepository>                   tasksRepository_;
   std::function<std::unique_ptr<TaskRepository>()>  repositoryFactory_;

--- a/core/Memory_Model/Storage/TaskRepositoryController.h
+++ b/core/Memory_Model/Storage/TaskRepositoryController.h
@@ -1,0 +1,24 @@
+//
+// Created by valeriisudakov on 03.10.20.
+//
+
+#ifndef TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_
+#define TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_
+#include "TaskRepository.h"
+
+class TaskRepositoryController {
+ public:
+  TaskRepositoryController(const std::function<std::unique_ptr<TaskRepository>()>& repositoryFactory)
+    : repositoryFactory_(repositoryFactory) {
+      tasksRepository_ = std::move(repositoryFactory_());
+  }
+
+ public:
+  const std::unique_ptr<TaskRepository>&            Get() const;
+
+ private:
+  std::unique_ptr<TaskRepository>                   tasksRepository_;
+  std::function<std::unique_ptr<TaskRepository>()>  repositoryFactory_;
+};
+
+#endif //TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_

--- a/core/Persister/TaskPersister.cpp
+++ b/core/Persister/TaskPersister.cpp
@@ -12,7 +12,10 @@ bool TaskPersister::Load() {
 
   for (auto& task : storage.tasks()){
     auto taskDTO = PersisterUtils::DTOFromSerializedTask(task);
-    auto addTaskResult = repository_.AddTask(taskDTO);
+    if (!taskDTO.has_value()){
+      return false;
+    }
+    auto addTaskResult = repository_.AddTask(taskDTO.value());
     if (!addTaskResult.success_){
       return false;
     }

--- a/core/Persister/TaskPersisterUtils.cpp
+++ b/core/Persister/TaskPersisterUtils.cpp
@@ -3,7 +3,11 @@
 //
 
 #include "TaskPersisterUtils.h"
+#include "Persister/TaskPersister.h"
 
+std::unique_ptr<Persister> PersisterUtils::CreatePersister(TaskRepository &repository, std::fstream &stream) {
+  return std::move(std::make_unique<TaskPersister>(repository, stream));
+}
 
 void PersisterUtils::SerializedTaskFromDTO(const TaskRepositoryDTO& taskDTO,
                                            Serialized::Task& task){

--- a/core/Persister/TaskPersisterUtils.cpp
+++ b/core/Persister/TaskPersisterUtils.cpp
@@ -19,13 +19,12 @@ void PersisterUtils::SerializedTaskFromDTO(const TaskRepositoryDTO& taskDTO,
 }
 
 
-TaskRepositoryDTO PersisterUtils::DTOFromSerializedTask(const Serialized::Task& task){
+std::optional<TaskRepositoryDTO> PersisterUtils::DTOFromSerializedTask(const Serialized::Task& task){
   auto dto = TaskRepositoryDTO::Create(task.name(), task.label(),
                                        SerializedPriorityToPriority(task.priority()),
                                        Date(boost::gregorian::date(task.date())),
                                        task.complete(), TaskID(), TaskID());
-  assert(dto.has_value());
-  return dto.value();
+  return dto;
 }
 
 void PersisterUtils::AddSubtasksToRepository(const Serialized::Task& serializedTask, TaskID& rootID, TaskRepository& repository_){
@@ -36,7 +35,7 @@ void PersisterUtils::AddSubtasksToRepository(const Serialized::Task& serializedT
   for (auto& subtask : serializedTask.subtasks()){
     auto subtaskDTO    = PersisterUtils::DTOFromSerializedTask(subtask);
 
-    auto addTaskResult = repository_.AddSubtask(rootID, subtaskDTO);
+    auto addTaskResult = repository_.AddSubtask(rootID, subtaskDTO.value());
 
     AddSubtasksToRepository(subtask, addTaskResult.id_.value(), repository_);
   }

--- a/core/Persister/TaskPersisterUtils.cpp
+++ b/core/Persister/TaskPersisterUtils.cpp
@@ -24,18 +24,17 @@ TaskRepositoryDTO PersisterUtils::DTOFromSerializedTask(const Serialized::Task& 
   return dto.value();
 }
 
-void PersisterUtils::AddSubtasksToRepository(Serialized::Task& serializedTask, TaskID& rootID, TaskRepository& repository_){
+void PersisterUtils::AddSubtasksToRepository(const Serialized::Task& serializedTask, TaskID& rootID, TaskRepository& repository_){
   if (serializedTask.subtasks().empty()){
     return;
   }
 
   for (auto& subtask : serializedTask.subtasks()){
-    auto subtaskDTO = PersisterUtils::DTOFromSerializedTask(subtask);
+    auto subtaskDTO    = PersisterUtils::DTOFromSerializedTask(subtask);
 
     auto addTaskResult = repository_.AddSubtask(rootID, subtaskDTO);
 
-    auto nonConstTask = subtask;
-    AddSubtasksToRepository(nonConstTask, addTaskResult.id_.value(), repository_);
+    AddSubtasksToRepository(subtask, addTaskResult.id_.value(), repository_);
   }
 }
 

--- a/core/Persister/TaskPersisterUtils.h
+++ b/core/Persister/TaskPersisterUtils.h
@@ -22,7 +22,7 @@ namespace PersisterUtils{
   void                                  AddSubtasksToRepository(const Serialized::Task& serializedTask, TaskID& rootID,
                                                                 TaskRepository& repository_);
 
-  TaskRepositoryDTO                     DTOFromSerializedTask(const Serialized::Task& task);
+  std::optional<TaskRepositoryDTO>      DTOFromSerializedTask(const Serialized::Task& task);
 
   std::unique_ptr<Persister>            CreatePersister(TaskRepository& repository, std::fstream& stream);
 }

--- a/core/Persister/TaskPersisterUtils.h
+++ b/core/Persister/TaskPersisterUtils.h
@@ -17,7 +17,7 @@ namespace PersisterUtils{
   void                                  AddSubtasks(Serialized::Task& serializedTask, TaskRepositoryDTO& task,
                                                     TaskRepository& repository_);
 
-  void                                  AddSubtasksToRepository(Serialized::Task& serializedTask, TaskID& rootID,
+  void                                  AddSubtasksToRepository(const Serialized::Task& serializedTask, TaskID& rootID,
                                                                 TaskRepository& repository_);
 
   TaskRepositoryDTO                     DTOFromSerializedTask(const Serialized::Task& task);

--- a/core/Persister/TaskPersisterUtils.h
+++ b/core/Persister/TaskPersisterUtils.h
@@ -7,6 +7,8 @@
 #include "Memory_Model/Storage/TaskRepository.h"
 #include "SerializedModel.pb.h"
 
+class Persister;
+
 namespace PersisterUtils{
   Priority                              SerializedPriorityToPriority(const Serialized::Priority& priority);
   Serialized::Priority                  PriorityToSerializedPriority(const Priority& priority);
@@ -21,6 +23,8 @@ namespace PersisterUtils{
                                                                 TaskRepository& repository_);
 
   TaskRepositoryDTO                     DTOFromSerializedTask(const Serialized::Task& task);
+
+  std::unique_ptr<Persister>            CreatePersister(TaskRepository& repository, std::fstream& stream);
 }
 
 #endif //TASKMANAGER_CORE_PERSISTER_TASKPERSISTERUTILS_H_

--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@
 
 int main(){
   auto io = std::make_shared<InputOutputConsoleLayer>();
-  std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(TaskServiceClass::Create());
+  std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory());
   auto menu = Factory::CreateMenuStateMachine(StatesID::BASE_MENU,
                                                std::make_shared<Context>(*service),*io );
   menu->Execute();

--- a/tests/cli/TestFactory.cpp
+++ b/tests/cli/TestFactory.cpp
@@ -16,6 +16,8 @@ class MockService : public TaskService{
   MOCK_METHOD(bool,                          RemoveTask,         (const TaskID&), (override));
   MOCK_METHOD(bool,                          PostponeTask,       (const TaskID&, const Date&), (override));
   MOCK_METHOD(bool,                          SetTaskComplete,    (const TaskID&), (override));
+  MOCK_METHOD(bool,                          Save, (), (override));
+  MOCK_METHOD(bool,                          Load, (), (override));
   MOCK_METHOD(std::optional<TaskServiceDTO>, GetTask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetSubtask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasks, (bool), (const override));

--- a/tests/cli/TestFactory.cpp
+++ b/tests/cli/TestFactory.cpp
@@ -11,19 +11,19 @@
 
 class MockService : public TaskService{
  public:
-  MOCK_METHOD(AddTaskResult,          AddTask,            (const TaskDTO&), (override));
-  MOCK_METHOD(AddTaskResult,          AddSubtask,         (const TaskID&, const TaskDTO&), (override));
-  MOCK_METHOD(bool,                   RemoveTask,         (const TaskID&), (override));
-  MOCK_METHOD(bool,                   PostponeTask,       (const TaskID&, const Date&), (override));
-  MOCK_METHOD(bool,                   SetTaskComplete,    (const TaskID&), (override));
+  MOCK_METHOD(AddTaskResult,                 AddTask,            (const TaskServiceDTO&), (override));
+  MOCK_METHOD(AddTaskResult,                 AddSubtask,         (const TaskID&, const TaskServiceDTO&), (override));
+  MOCK_METHOD(bool,                          RemoveTask,         (const TaskID&), (override));
+  MOCK_METHOD(bool,                          PostponeTask,       (const TaskID&, const Date&), (override));
+  MOCK_METHOD(bool,                          SetTaskComplete,    (const TaskID&), (override));
   MOCK_METHOD(std::optional<TaskServiceDTO>, GetTask, (const TaskID&), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetSubtask, (const TaskID&), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasks, (bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTodayTasks, (bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetWeekTasks, (bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasksByName, (const std::string&, bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasksByLabel, (const std::string&, bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasksByPriority, (const Priority&), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetSubtask, (const TaskID&), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasks, (bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTodayTasks, (bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetWeekTasks, (bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByName, (const std::string&, bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByLabel, (const std::string&, bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByPriority, (const Priority&), (const override));
 
 };
 

--- a/tests/cli/TestFininteStatesMachine.cpp
+++ b/tests/cli/TestFininteStatesMachine.cpp
@@ -24,6 +24,8 @@ class MockService : public TaskService{
   MOCK_METHOD(bool,                          RemoveTask,         (const TaskID&), (override));
   MOCK_METHOD(bool,                          PostponeTask,       (const TaskID&, const Date&), (override));
   MOCK_METHOD(bool,                          SetTaskComplete,    (const TaskID&), (override));
+  MOCK_METHOD(bool,                          Save, (), (override));
+  MOCK_METHOD(bool,                          Load, (), (override));
   MOCK_METHOD(std::optional<TaskServiceDTO>, GetTask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetSubtask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasks, (bool), (const override));

--- a/tests/cli/TestFininteStatesMachine.cpp
+++ b/tests/cli/TestFininteStatesMachine.cpp
@@ -19,19 +19,19 @@ class MockIO : public InputOutputLayer{
 
 class MockService : public TaskService{
  public:
-  MOCK_METHOD(AddTaskResult,          AddTask,            (const TaskDTO&), (override));
-  MOCK_METHOD(AddTaskResult,          AddSubtask,         (const TaskID&, const TaskDTO&), (override));
-  MOCK_METHOD(bool,                   RemoveTask,         (const TaskID&), (override));
-  MOCK_METHOD(bool,                   PostponeTask,       (const TaskID&, const Date&), (override));
-  MOCK_METHOD(bool,                   SetTaskComplete,    (const TaskID&), (override));
+  MOCK_METHOD(AddTaskResult,                 AddTask,            (const TaskServiceDTO&), (override));
+  MOCK_METHOD(AddTaskResult,                 AddSubtask,         (const TaskID&, const TaskServiceDTO&), (override));
+  MOCK_METHOD(bool,                          RemoveTask,         (const TaskID&), (override));
+  MOCK_METHOD(bool,                          PostponeTask,       (const TaskID&, const Date&), (override));
+  MOCK_METHOD(bool,                          SetTaskComplete,    (const TaskID&), (override));
   MOCK_METHOD(std::optional<TaskServiceDTO>, GetTask, (const TaskID&), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetSubtask, (const TaskID&), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasks, (bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTodayTasks, (bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetWeekTasks, (bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasksByName, (const std::string&, bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasksByLabel, (const std::string&, bool), (const override));
-  MOCK_METHOD(std::vector<TaskServiceDTO>, GetTasksByPriority, (const Priority&), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetSubtask, (const TaskID&), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasks, (bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTodayTasks, (bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetWeekTasks, (bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByName, (const std::string&, bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByLabel, (const std::string&, bool), (const override));
+  MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByPriority, (const Priority&), (const override));
 
 };
 
@@ -76,7 +76,7 @@ TEST_F(TestFiniteStatesMachine, shouldCorrectChangeStatesMenuStatesMachine) {
                                       .WillOnce(Return("now"))
                                       .WillOnce((Return("exit")));
 
-  EXPECT_CALL(*service, AddTask).Times(1).WillOnce(Return(AddTaskResult(true)));
+  EXPECT_CALL(*service, AddTask).Times(1).WillOnce(Return(AddTaskResult::Success(TaskID())));
   auto inputNameMachine = Factory::CreateMenuStateMachine(StatesID::BASE_MENU,
                                                         context,
                                                         *io);

--- a/tests/cli/TestInputStates.cpp
+++ b/tests/cli/TestInputStates.cpp
@@ -17,6 +17,8 @@ class MockService : public TaskService{
   MOCK_METHOD(bool,                          RemoveTask,         (const TaskID&), (override));
   MOCK_METHOD(bool,                          PostponeTask,       (const TaskID&, const Date&), (override));
   MOCK_METHOD(bool,                          SetTaskComplete,    (const TaskID&), (override));
+  MOCK_METHOD(bool,                          Save, (), (override));
+  MOCK_METHOD(bool,                          Load, (), (override));
   MOCK_METHOD(std::optional<TaskServiceDTO>, GetTask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetSubtask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasks, (bool), (const override));

--- a/tests/cli/TestInputStates.cpp
+++ b/tests/cli/TestInputStates.cpp
@@ -25,7 +25,6 @@ class MockService : public TaskService{
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByName, (const std::string&, bool), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByLabel, (const std::string&, bool), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasksByPriority, (const Priority&), (const override));
-
 };
 
 class MockIO : public InputOutputLayer{
@@ -50,7 +49,7 @@ class TestInput :  public ::testing::Test {
 using ::testing::Return;
 
 
-TEST_F(TestInput, shouldBeCorrectInputName){
+TEST_F(TestInput, shouldCorrectInputName){
   EXPECT_CALL(*io, Output).Times(3).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(2).WillOnce(Return(""))
                                       .WillOnce(Return("name"));
@@ -63,7 +62,7 @@ TEST_F(TestInput, shouldBeCorrectInputName){
   ASSERT_EQ(context->buffer_.name, "name");
 }
 
-TEST_F(TestInput, shouldCorrectInputLabel){
+TEST_F(TestInput, shouldBeCorrectLabelInput){
   EXPECT_CALL(*io, Output).Times(3).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(2).WillOnce(Return(""))
       .WillOnce(Return("label"));
@@ -76,7 +75,7 @@ TEST_F(TestInput, shouldCorrectInputLabel){
 }
 
 
-TEST_F(TestInput, shouldCorrectInputDatetime){
+TEST_F(TestInput, shouldCorrectInputDate){
   EXPECT_CALL(*io, Output).Times(1).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(1).WillOnce(Return("now"));
   auto date = Factory::CreateFiniteStatesMachine(FiniteStateMachineID::INPUT_DATE,

--- a/tests/cli/TestInputTaskParams.cpp
+++ b/tests/cli/TestInputTaskParams.cpp
@@ -17,6 +17,8 @@ class MockService : public TaskService{
   MOCK_METHOD(bool,                          RemoveTask,         (const TaskID&), (override));
   MOCK_METHOD(bool,                          PostponeTask,       (const TaskID&, const Date&), (override));
   MOCK_METHOD(bool,                          SetTaskComplete,    (const TaskID&), (override));
+  MOCK_METHOD(bool,                          Save, (), (override));
+  MOCK_METHOD(bool,                          Load, (), (override));
   MOCK_METHOD(std::optional<TaskServiceDTO>, GetTask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetSubtask, (const TaskID&), (const override));
   MOCK_METHOD(std::vector<TaskServiceDTO>,   GetTasks, (bool), (const override));

--- a/tests/cli/TestStateMachinesFactory.cpp
+++ b/tests/cli/TestStateMachinesFactory.cpp
@@ -11,7 +11,7 @@ class TestStatesMachineFactory :  public ::testing::Test {
  protected:
   virtual void SetUp() override{
     io = std::make_shared<InputOutputConsoleLayer>();
-    context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(TaskServiceClass::Create()));
+    context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory()));
 
   }
 

--- a/tests/core/TestTask.cpp
+++ b/tests/core/TestTask.cpp
@@ -7,6 +7,7 @@
 //
 #include <gtest/gtest.h>
 #include "Memory_Model/Task/TaskEntity.h"
+#include "Memory_Model/Task/TaskIDGenerate.h"
 #include "API/TaskServiceClass.h"
 #include "API/Priority.h"
 #include "Date/Date.h"

--- a/tests/core/TestTaskRepositoryController.cpp
+++ b/tests/core/TestTaskRepositoryController.cpp
@@ -1,0 +1,41 @@
+//
+// Created by valeriisudakov on 03.10.20.
+//
+
+#include <gtest/gtest.h>
+#include "Memory_Model/Storage/TaskRepositoryController.h"
+#include "API/TaskServiceUtils.h"
+
+class TestTaskRepositoryController : public ::testing::Test {
+ protected:
+  void SetUp() override{
+    repository = std::make_unique<TaskRepositoryController>(TaskServiceUtils::GetRepositoryFactory());
+  }
+ protected:
+  std::unique_ptr<TaskRepositoryController> repository;
+};
+
+TEST_F(TestTaskRepositoryController, shouldSaveAndLoad){
+  auto testTask = TaskRepositoryDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
+  ASSERT_TRUE(testTask.has_value());
+  auto addTaskResult = repository->Get()->AddTask(testTask.value());
+  ASSERT_TRUE(addTaskResult.success_);
+
+  auto testSubtask = TaskRepositoryDTO::Create("sub task", "label", Priority::NONE, Date::GetCurrentTime());
+  ASSERT_TRUE(testSubtask.has_value());
+  auto addSubtaskResult = repository->Get()->AddSubtask(addTaskResult.id_.value(), testSubtask.value());
+  ASSERT_TRUE(addSubtaskResult.success_);
+
+  ASSERT_TRUE(repository->Save());
+  ASSERT_TRUE(repository->Load());
+
+  auto tasks = repository->Get()->GetTasks();
+  ASSERT_EQ(tasks.size(), 2);
+  ASSERT_EQ(tasks[0].GetName(), "task");
+  ASSERT_EQ(tasks[0].GetLabel(), "label");
+  ASSERT_EQ(tasks[0].GetPriority(), Priority::NONE);
+  ASSERT_EQ(tasks[0].GetDate().Get().day_number(), Date::GetCurrentTime().day_number());
+
+  auto subtaskFirst = repository->Get()->GetSubtask(tasks[0].GetID());
+  ASSERT_EQ(subtaskFirst.size(), 1);
+}

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -4,7 +4,7 @@
 
 
 #include <gtest/gtest.h>
-//#include <gmock/gmock.h>
+#include <gmock/gmock.h>
 #include "API/TaskServiceClass.h"
 #include <iostream>
 
@@ -12,7 +12,7 @@ class TestTaskService : public ::testing::Test {
 
  protected:
   virtual void SetUp() {
-    ts = std::make_unique<TaskServiceClass>(TaskServiceClass::Create());
+    ts = std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory());
   }
   std::unique_ptr<TaskService> ts;
 };
@@ -49,7 +49,7 @@ TEST_F(TestTaskService, shouldCreateSubTask) {
   auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
-  
+
   std::optional<Task> subTask = Task::Create("sub task", "label", Priority::NONE, Date::GetCurrentTime());
   auto dto = TaskServiceDTO::Create(subTask.value().GetName(), subTask.value().GetLabel(),
                                             subTask.value().GetPriority(), subTask.value().GetDueDate());

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -23,18 +23,14 @@ class FakeRepository : public TaskRepository{
 };
 
 TEST_F(TestTaskService, shouldAddTask) {
-  std::optional<Task> task = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto dto = TaskServiceDTO::Create(task.value().GetName(), task.value().GetLabel(),
-                                            task.value().GetPriority(), task.value().GetDueDate());
+  auto dto = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(dto.has_value());
   auto result = ts->AddTask(dto.value());
   ASSERT_TRUE(result.success_);
 }
 
 TEST_F(TestTaskService, shouldCreateTask) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -44,15 +40,10 @@ TEST_F(TestTaskService, shouldCreateTask) {
 
 
 TEST_F(TestTaskService, shouldCreateSubTask) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
-
-  std::optional<Task> subTask = Task::Create("sub task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto dto = TaskServiceDTO::Create(subTask.value().GetName(), subTask.value().GetLabel(),
-                                            subTask.value().GetPriority(), subTask.value().GetDueDate());
+  auto dto = TaskServiceDTO::Create("sub task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(dto.has_value());
   auto taskTest = ts->GetTasksByName("task", false);
   auto result = ts->AddSubtask(taskTest[0].GetTaskId(), dto.value());
@@ -60,16 +51,10 @@ TEST_F(TestTaskService, shouldCreateSubTask) {
 }
 
 TEST_F(TestTaskService, shouldntCreateSubTaskWithIncorrectID) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
-
-  TaskIDGenerate idGenerate;
-  std::optional<Task> subTask = Task::Create("sub task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto dto = TaskServiceDTO::Create(subTask.value().GetName(), subTask.value().GetLabel(),
-                                            subTask.value().GetPriority(), subTask.value().GetDueDate());
+  auto dto = TaskServiceDTO::Create("sub task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(dto.has_value());
   TaskID incorrectID(987);
   auto result = ts->AddSubtask(incorrectID, dto.value());
@@ -77,9 +62,7 @@ TEST_F(TestTaskService, shouldntCreateSubTaskWithIncorrectID) {
 }
 
 TEST_F(TestTaskService, shouldPostpone){
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -97,9 +80,7 @@ TEST_F(TestTaskService, shouldntPostpone){
   ASSERT_FALSE(task);}
 
 TEST_F(TestTaskService, shouldGetByID) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -108,16 +89,12 @@ TEST_F(TestTaskService, shouldGetByID) {
 }
 
 TEST_F(TestTaskService, shouldntGetByID) {
-
-
   auto result = ts->GetTask(TaskID(1245563));
   ASSERT_FALSE(result.has_value());
 }
 
 TEST_F(TestTaskService, shouldFoundTaskByName) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -126,9 +103,7 @@ TEST_F(TestTaskService, shouldFoundTaskByName) {
 }
 
 TEST_F(TestTaskService, shouldFoundTaskByNameAndPriority) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -137,16 +112,12 @@ TEST_F(TestTaskService, shouldFoundTaskByNameAndPriority) {
 }
 
 TEST_F(TestTaskService, shouldNotFoundTaskByName) {
-
-
   auto resultSearch = ts->GetTasksByName("asf125safs", false);
   ASSERT_TRUE(resultSearch.empty());
 }
 
 TEST_F(TestTaskService, shouldFoundTaskByLabel) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -155,9 +126,7 @@ TEST_F(TestTaskService, shouldFoundTaskByLabel) {
 }
 
 TEST_F(TestTaskService, shouldFoundTaskByLabelAndPriority) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -166,16 +135,12 @@ TEST_F(TestTaskService, shouldFoundTaskByLabelAndPriority) {
 }
 
 TEST_F(TestTaskService, shouldNotFoundTaskByLabel) {
-
-
   auto resultSearch = ts->GetTasksByLabel("124rwfsaa21", false);
   ASSERT_TRUE(resultSearch.empty());
 }
 
 TEST_F(TestTaskService, shouldFoundTasks) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -184,9 +149,7 @@ TEST_F(TestTaskService, shouldFoundTasks) {
 }
 
 TEST_F(TestTaskService, shouldFoundTasksByPriority) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -195,16 +158,12 @@ TEST_F(TestTaskService, shouldFoundTasksByPriority) {
 }
 
 TEST_F(TestTaskService, shouldNotFoundTasks) {
-
-
   auto resultSearch = ts->GetTasks(false);
   ASSERT_TRUE(resultSearch.empty());
 }
 
 TEST_F(TestTaskService, shouldFoundTodayTasks) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -213,9 +172,7 @@ TEST_F(TestTaskService, shouldFoundTodayTasks) {
 }
 
 TEST_F(TestTaskService, shouldFoundTodayTasksByPriority) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -224,15 +181,12 @@ TEST_F(TestTaskService, shouldFoundTodayTasksByPriority) {
 }
 
 TEST_F(TestTaskService, shouldNotFoundTodayTasks) {
-
   auto resultSearch = ts->GetTodayTasks(false);
   ASSERT_TRUE(resultSearch.empty());
 }
 
 TEST_F(TestTaskService, shouldFoundWeekTasks) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -241,9 +195,7 @@ TEST_F(TestTaskService, shouldFoundWeekTasks) {
 }
 
 TEST_F(TestTaskService, shouldFoundWeekTasksByPriority) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -258,9 +210,7 @@ TEST_F(TestTaskService, shouldNotFoundWeekTasks) {
 }
 
 TEST_F(TestTaskService, shouldFoundTasksPriority) {
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 
@@ -269,15 +219,12 @@ TEST_F(TestTaskService, shouldFoundTasksPriority) {
 }
 
 TEST_F(TestTaskService, shouldNotFoundTasksPriority) {
-
   auto resultSearch = ts->GetTasksByPriority(Priority::FIRST);
   ASSERT_TRUE(resultSearch.empty());
 }
 
 TEST_F(TestTaskService, shouldRemoveTask){
-
-  auto test = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
-  auto testDTO = TaskServiceDTO::Create(test->GetName(), test->GetLabel(), test->GetPriority(), test->GetDueDate());
+  auto testDTO = TaskServiceDTO::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
   ASSERT_TRUE(testDTO.has_value());
   ts->AddTask(testDTO.value());
 

--- a/tests/core/TestTaskView.cpp
+++ b/tests/core/TestTaskView.cpp
@@ -3,7 +3,7 @@
 //
 
 #include <gtest/gtest.h>
-#include "API/TaskServiceClass.h"
+#include "Memory_Model/Storage/TaskRepositoryClass.h"
 #include <iostream>
 
 class TestTaskView : public ::testing::Test {


### PR DESCRIPTION
- Changed AddTaskToRepository method
- Moved private convert methods of TaskService to TaskServiceUtils namespace.
- Added TaskRepositoryController class. Implemented it in TaskServiceClass. Tests were changed. This changed made in order to TaskService a class-transmitter.
- Include it in TaskService.
- Implement current changes on whole system