### PR TITLE
Change creation of repository and persister

### DIFF
--- a/core/API/TaskServiceClass.h
+++ b/core/API/TaskServiceClass.h
@@ -6,8 +6,7 @@
 #define TASKMANAGER_SRC_TASKSERVICE_H_
 #include "TaskService.h"
 #include "TaskServiceUtils.h"
-#include "Memory_Model/Storage/TaskRepositoryController.h"
-#include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
+#include "Memory_Model/Storage/RepositoryController.h"
 
 /*
  *  Enter point to the program.
@@ -18,8 +17,8 @@
  */
 class TaskServiceClass : public TaskService {
  public:
-  TaskServiceClass(std::unique_ptr<RepositoriesFactory> repositoryFactory)
-    : repositoryController_(std::move(std::make_unique<TaskRepositoryController>(std::move(repositoryFactory)))) { }
+  TaskServiceClass(std::unique_ptr<RepositoryController> repositoryFactory)
+    : repositoryController_(std::move(repositoryFactory)) { }
 
  public:
   AddTaskResult                    AddTask(const TaskServiceDTO& task) override;
@@ -43,7 +42,7 @@ class TaskServiceClass : public TaskService {
   std::vector<TaskServiceDTO>      GetTasksByPriority(const Priority& priority) const override;
 
  private:
-  std::unique_ptr<TaskRepositoryController> repositoryController_;
+  std::unique_ptr<RepositoryController> repositoryController_;
 };
 
 #endif //TASKMANAGER_SRC_TASKSERVICE_H_

--- a/core/API/TaskServiceClass.h
+++ b/core/API/TaskServiceClass.h
@@ -7,6 +7,8 @@
 #include "TaskService.h"
 #include "TaskServiceUtils.h"
 #include "Memory_Model/Storage/TaskRepositoryController.h"
+#include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
+
 /*
  *  Enter point to the program.
  *
@@ -16,8 +18,8 @@
  */
 class TaskServiceClass : public TaskService {
  public:
-  TaskServiceClass(const std::function<std::unique_ptr<TaskRepository>()>& repositoryFactory)
-    : repositoryController_(std::move(std::make_unique<TaskRepositoryController>(repositoryFactory))) { }
+  TaskServiceClass(std::unique_ptr<RepositoriesFactory> repositoryFactory)
+    : repositoryController_(std::move(std::make_unique<TaskRepositoryController>(std::move(repositoryFactory)))) { }
 
  public:
   AddTaskResult                    AddTask(const TaskServiceDTO& task) override;

--- a/core/API/TaskServiceUtils.cpp
+++ b/core/API/TaskServiceUtils.cpp
@@ -3,17 +3,6 @@
 //
 
 #include "TaskServiceUtils.h"
-#include "Memory_Model/Storage/TaskRepositoryClass.h"
-
-std::function<std::unique_ptr<TaskRepository>()> TaskServiceUtils::GetRepositoryFactory(){
-  auto factory = [](){
-    std::unique_ptr<TaskStorage> storage = std::make_unique<TaskStorageClass>();
-    std::unique_ptr<TaskView> view = std::make_unique<TaskViewClass>();
-    return std::move(std::make_unique<TaskRepositoryClass>(std::move(view), std::move(storage)));
-  };
-
-  return factory;
-}
 
 std::optional<TaskServiceDTO> TaskServiceUtils::MakeTaskDTO(const TaskRepositoryDTO& task) {
   auto newTask = TaskServiceDTO::Create(task.GetName(), task.GetLabel(), task.GetPriority(), task.GetDate(),

--- a/core/API/TaskServiceUtils.h
+++ b/core/API/TaskServiceUtils.h
@@ -10,12 +10,6 @@
 class TaskRepository;
 
 namespace TaskServiceUtils {
-/*
- *  Create and return pointer to factory-method of TaskRepository
- *
- *  @return-type: pointer to factory-method of TaskRepository
- */
-std::function<std::unique_ptr<TaskRepository>()> GetRepositoryFactory();
 
 /*
  * Converts from vector of TaskRepositoryDTO to vector of TaskServiceDTO

--- a/core/Memory_Model/RepositoriesFactory/RepositoriesFactory.h
+++ b/core/Memory_Model/RepositoriesFactory/RepositoriesFactory.h
@@ -1,0 +1,16 @@
+//
+// Created by valeriisudakov on 06.10.20.
+//
+
+#ifndef TASKMANAGER_CORE_MEMORY_MODEL_REPOSITORIESFACTORY_REPOSITORIESFACTORY_H_
+#define TASKMANAGER_CORE_MEMORY_MODEL_REPOSITORIESFACTORY_REPOSITORIESFACTORY_H_
+#include "Memory_Model/Storage/TaskRepository.h"
+
+class RepositoriesFactory{
+ public:
+  virtual ~RepositoriesFactory() = default;
+
+  virtual std::unique_ptr<TaskRepository> Create() = 0;
+};
+
+#endif //TASKMANAGER_CORE_MEMORY_MODEL_REPOSITORIESFACTORY_REPOSITORIESFACTORY_H_

--- a/core/Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h
+++ b/core/Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h
@@ -1,0 +1,18 @@
+//
+// Created by valeriisudakov on 06.10.20.
+//
+
+#ifndef TASKMANAGER_CORE_MEMORY_MODEL_REPOSITORIESFACTORY_TASKREPOSITORYFACTORY_H_
+#define TASKMANAGER_CORE_MEMORY_MODEL_REPOSITORIESFACTORY_TASKREPOSITORYFACTORY_H_
+#include "RepositoriesFactory.h"
+#include "Memory_Model/Storage/TaskRepositoryClass.h"
+
+class TaskRepositoryFactory : public RepositoriesFactory {
+ public:
+  std::unique_ptr<TaskRepository> Create() override{
+    auto storage = std::make_unique<TaskStorageClass>();
+    auto view = std::make_unique<TaskViewClass>();
+    return std::move(std::make_unique<TaskRepositoryClass>(std::move(view), std::move(storage)));
+  }
+};
+#endif //TASKMANAGER_CORE_MEMORY_MODEL_REPOSITORIESFACTORY_TASKREPOSITORYFACTORY_H_

--- a/core/Memory_Model/Storage/RepositoryController.h
+++ b/core/Memory_Model/Storage/RepositoryController.h
@@ -1,0 +1,19 @@
+//
+// Created by valeriisudakov on 06.10.20.
+//
+
+#ifndef TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_REPOSITORYCONTROLLER_H_
+#define TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_REPOSITORYCONTROLLER_H_
+#include <memory>
+#include "TaskRepository.h"
+
+class RepositoryController {
+ public:
+  virtual ~RepositoryController() = default;
+
+  virtual const std::unique_ptr<TaskRepository>&            Get() const = 0;
+  virtual bool                                              Save() = 0;
+  virtual bool                                              Load() = 0;
+};
+
+#endif //TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_REPOSITORYCONTROLLER_H_

--- a/core/Memory_Model/Storage/TaskRepositoryController.cpp
+++ b/core/Memory_Model/Storage/TaskRepositoryController.cpp
@@ -12,7 +12,7 @@ const std::unique_ptr<TaskRepository>& TaskRepositoryController::Get() const {
 
 bool TaskRepositoryController::Save() {
   std::fstream file("Tasks.txt", std::ios::out);
-  auto persister = PersisterUtils::CreatePersister(*tasksRepository_, file);
+  auto persister = PersisterUtils::Create(*tasksRepository_, file);
   auto result = persister->Save();
   file.close();
   return result;
@@ -21,7 +21,7 @@ bool TaskRepositoryController::Save() {
 bool TaskRepositoryController::Load() {
   std::fstream file("Tasks.txt", std::ios::in);
   auto newRepository = std::move(repositoryFactory_->Create());
-  auto persister = PersisterUtils::CreatePersister(*newRepository, file);
+  auto persister = PersisterUtils::Create(*newRepository, file);
   auto result = persister->Load();
 
   if (result){

--- a/core/Memory_Model/Storage/TaskRepositoryController.cpp
+++ b/core/Memory_Model/Storage/TaskRepositoryController.cpp
@@ -20,7 +20,7 @@ bool TaskRepositoryController::Save() {
 
 bool TaskRepositoryController::Load() {
   std::fstream file("Tasks.txt", std::ios::in);
-  auto newRepository = repositoryFactory_();
+  auto newRepository = std::move(repositoryFactory_->Create());
   auto persister = PersisterUtils::CreatePersister(*newRepository, file);
   auto result = persister->Load();
 

--- a/core/Memory_Model/Storage/TaskRepositoryController.h
+++ b/core/Memory_Model/Storage/TaskRepositoryController.h
@@ -5,12 +5,13 @@
 #ifndef TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_
 #define TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_
 #include "TaskRepository.h"
+#include "Memory_Model/RepositoriesFactory/RepositoriesFactory.h"
 
 class TaskRepositoryController {
  public:
-  TaskRepositoryController(const std::function<std::unique_ptr<TaskRepository>()>& repositoryFactory)
-    : repositoryFactory_(repositoryFactory) {
-      tasksRepository_ = std::move(repositoryFactory_());
+  TaskRepositoryController(std::unique_ptr<RepositoriesFactory> repositoryFactory)
+    : repositoryFactory_(std::move(repositoryFactory)) {
+    tasksRepository_ = std::move(repositoryFactory_->Create());
   }
 
  public:
@@ -19,7 +20,7 @@ class TaskRepositoryController {
   bool                                              Load();
  private:
   std::unique_ptr<TaskRepository>                   tasksRepository_;
-  std::function<std::unique_ptr<TaskRepository>()>  repositoryFactory_;
+  std::unique_ptr<RepositoriesFactory>              repositoryFactory_;
 };
 
 #endif //TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_

--- a/core/Memory_Model/Storage/TaskRepositoryController.h
+++ b/core/Memory_Model/Storage/TaskRepositoryController.h
@@ -4,10 +4,10 @@
 
 #ifndef TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_
 #define TASKMANAGER_CORE_MEMORY_MODEL_STORAGE_TASKREPOSITORYCONTOLLER_H_
-#include "TaskRepository.h"
 #include "Memory_Model/RepositoriesFactory/RepositoriesFactory.h"
+#include "RepositoryController.h"
 
-class TaskRepositoryController {
+class TaskRepositoryController : public RepositoryController{
  public:
   TaskRepositoryController(std::unique_ptr<RepositoriesFactory> repositoryFactory)
     : repositoryFactory_(std::move(repositoryFactory)) {

--- a/core/Persister/TaskPersisterUtils.cpp
+++ b/core/Persister/TaskPersisterUtils.cpp
@@ -5,7 +5,7 @@
 #include "TaskPersisterUtils.h"
 #include "Persister/TaskPersister.h"
 
-std::unique_ptr<Persister> PersisterUtils::CreatePersister(TaskRepository &repository, std::fstream &stream) {
+std::unique_ptr<Persister> PersisterUtils::Create(TaskRepository &repository, std::fstream &stream) {
   return std::move(std::make_unique<TaskPersister>(repository, stream));
 }
 

--- a/core/Persister/TaskPersisterUtils.h
+++ b/core/Persister/TaskPersisterUtils.h
@@ -24,7 +24,7 @@ namespace PersisterUtils{
 
   std::optional<TaskRepositoryDTO>      DTOFromSerializedTask(const Serialized::Task& task);
 
-  std::unique_ptr<Persister>            CreatePersister(TaskRepository& repository, std::fstream& stream);
+  std::unique_ptr<Persister>            Create(TaskRepository& repository, std::fstream& stream);
 }
 
 #endif //TASKMANAGER_CORE_PERSISTER_TASKPERSISTERUTILS_H_

--- a/main.cpp
+++ b/main.cpp
@@ -2,12 +2,14 @@
 #include "StatesControllers/StateMachineMenu.h"
 #include "InputOutputConsoleLayer.h"
 #include "States/StatesID.h"
+#include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
 
 #include "Factory/Factory.h"
 
 int main(){
+  std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
+  std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(std::move(factory));
   auto io = std::make_shared<InputOutputConsoleLayer>();
-  std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory());
   auto menu = Factory::CreateMenuStateMachine(StatesID::BASE_MENU,
                                                std::make_shared<Context>(*service),*io );
   menu->Execute();

--- a/main.cpp
+++ b/main.cpp
@@ -3,15 +3,19 @@
 #include "InputOutputConsoleLayer.h"
 #include "States/StatesID.h"
 #include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
-
+#include "Memory_Model/Storage/TaskRepositoryController.h"
 #include "Factory/Factory.h"
 
 int main(){
   std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
-  std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(std::move(factory));
+  std::unique_ptr<RepositoryController> controller = std::make_unique<TaskRepositoryController>(std::move(std::move(factory)));
+  std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(std::move(controller));
+
   auto io = std::make_shared<InputOutputConsoleLayer>();
+
   auto menu = Factory::CreateMenuStateMachine(StatesID::BASE_MENU,
                                                std::make_shared<Context>(*service),*io );
+
   menu->Execute();
   return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -8,7 +8,7 @@
 
 int main(){
   std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
-  std::unique_ptr<RepositoryController> controller = std::make_unique<TaskRepositoryController>(std::move(std::move(factory)));
+  std::unique_ptr<RepositoryController> controller = std::make_unique<TaskRepositoryController>(std::move(factory));
   std::unique_ptr<TaskService> service = std::make_unique<TaskServiceClass>(std::move(controller));
 
   auto io = std::make_shared<InputOutputConsoleLayer>();

--- a/tests/cli/TestInputStates.cpp
+++ b/tests/cli/TestInputStates.cpp
@@ -31,8 +31,8 @@ TEST_F(TestInput, shouldCorrectInputName){
   EXPECT_CALL(*io, Output).Times(3).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(2).WillOnce(Return(""))
                                       .WillOnce(Return("name"));
-
-  auto context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory()));
+  std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
+  auto context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(std::move(factory)));
   auto name = Factory::CreateFiniteStatesMachine(FiniteStateMachineID::INPUT_NAME,
                                                  context,
                                                  *io);

--- a/tests/cli/TestInputStates.cpp
+++ b/tests/cli/TestInputStates.cpp
@@ -31,8 +31,8 @@ TEST_F(TestInput, shouldCorrectInputName){
   EXPECT_CALL(*io, Output).Times(3).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(2).WillOnce(Return(""))
                                       .WillOnce(Return("name"));
-  std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
-  auto context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(std::move(factory)));
+
+  auto context = std::make_shared<Context>(*std::make_unique<MockService>());
   auto name = Factory::CreateFiniteStatesMachine(FiniteStateMachineID::INPUT_NAME,
                                                  context,
                                                  *io);

--- a/tests/cli/TestInputTaskParams.cpp
+++ b/tests/cli/TestInputTaskParams.cpp
@@ -32,8 +32,7 @@ TEST_F(TestInput, shouldBeCorrectInputName){
   EXPECT_CALL(*io, Output).Times(3).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(2).WillOnce(Return(""))
                                       .WillOnce(Return("name"));
-  auto factory = std::make_unique<TaskRepositoryFactory>();
-  auto context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(std::move(factory)));
+  auto context = std::make_shared<Context>(*std::make_unique<MockService>());
   auto name = Factory::CreateFiniteStatesMachine(FiniteStateMachineID::INPUT_NAME,
                                                  context,
                                                  *io);

--- a/tests/cli/TestInputTaskParams.cpp
+++ b/tests/cli/TestInputTaskParams.cpp
@@ -32,8 +32,8 @@ TEST_F(TestInput, shouldBeCorrectInputName){
   EXPECT_CALL(*io, Output).Times(3).WillRepeatedly(Return());
   EXPECT_CALL(*io, Input).Times(2).WillOnce(Return(""))
                                       .WillOnce(Return("name"));
-
-  auto context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory()));
+  auto factory = std::make_unique<TaskRepositoryFactory>();
+  auto context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(std::move(factory)));
   auto name = Factory::CreateFiniteStatesMachine(FiniteStateMachineID::INPUT_NAME,
                                                  context,
                                                  *io);

--- a/tests/cli/TestStateMachinesFactory.cpp
+++ b/tests/cli/TestStateMachinesFactory.cpp
@@ -6,13 +6,17 @@
 #include "Factory/FactoryExecuteStatesMachine.h"
 #include "InputOutputConsoleLayer.h"
 #include <memory>
+#include "mock/Service.h"
+#include "mock/InputOutput.h"
+
+using ::MockIO;
+using ::MockService;
 
 class TestStatesMachineFactory :  public ::testing::Test {
  protected:
   virtual void SetUp() override{
-    io = std::make_shared<InputOutputConsoleLayer>();
-    auto factory = std::make_unique<TaskRepositoryFactory>();
-    context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(std::move(factory)));
+    io = std::make_shared<MockIO>();
+    context = std::make_shared<Context>(*std::make_unique<MockService>());
 
   }
 

--- a/tests/cli/TestStateMachinesFactory.cpp
+++ b/tests/cli/TestStateMachinesFactory.cpp
@@ -11,7 +11,8 @@ class TestStatesMachineFactory :  public ::testing::Test {
  protected:
   virtual void SetUp() override{
     io = std::make_shared<InputOutputConsoleLayer>();
-    context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory()));
+    auto factory = std::make_unique<TaskRepositoryFactory>();
+    context = std::make_shared<Context>(*std::make_unique<TaskServiceClass>(std::move(factory)));
 
   }
 

--- a/tests/core/TestTaskRepositoryController.cpp
+++ b/tests/core/TestTaskRepositoryController.cpp
@@ -5,11 +5,13 @@
 #include <gtest/gtest.h>
 #include "Memory_Model/Storage/TaskRepositoryController.h"
 #include "API/TaskServiceUtils.h"
+#include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
 
 class TestTaskRepositoryController : public ::testing::Test {
  protected:
   void SetUp() override{
-    repository = std::make_unique<TaskRepositoryController>(TaskServiceUtils::GetRepositoryFactory());
+    auto factory = std::make_unique<TaskRepositoryFactory>();
+    repository = std::make_unique<TaskRepositoryController>(std::move(factory));
   }
  protected:
   std::unique_ptr<TaskRepositoryController> repository;

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -13,8 +13,8 @@ class TestTaskService : public ::testing::Test {
 
  protected:
   virtual void SetUp() {
-    std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
-    std::unique_ptr<RepositoryController> controller = std::make_unique<TaskRepositoryController>(std::move(std::move(factory)));
+    auto factory = std::make_unique<TaskRepositoryFactory>();
+    auto controller = std::make_unique<TaskRepositoryController>(std::move(std::move(factory)));
     ts = std::make_unique<TaskServiceClass>(std::move(controller));
   }
   std::unique_ptr<TaskService> ts;

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -14,7 +14,7 @@ class TestTaskService : public ::testing::Test {
  protected:
   virtual void SetUp() {
     auto factory = std::make_unique<TaskRepositoryFactory>();
-    auto controller = std::make_unique<TaskRepositoryController>(std::move(std::move(factory)));
+    auto controller = std::make_unique<TaskRepositoryController>(std::move(factory));
     ts = std::make_unique<TaskServiceClass>(std::move(controller));
   }
   std::unique_ptr<TaskService> ts;

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -8,13 +8,14 @@
 #include "API/TaskServiceClass.h"
 #include <iostream>
 #include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
-
+#include "Memory_Model/Storage/TaskRepositoryController.h"
 class TestTaskService : public ::testing::Test {
 
  protected:
   virtual void SetUp() {
     std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
-    ts = std::make_unique<TaskServiceClass>(std::move(factory));
+    std::unique_ptr<RepositoryController> controller = std::make_unique<TaskRepositoryController>(std::move(std::move(factory)));
+    ts = std::make_unique<TaskServiceClass>(std::move(controller));
   }
   std::unique_ptr<TaskService> ts;
 };

--- a/tests/core/TestTaskService.cpp
+++ b/tests/core/TestTaskService.cpp
@@ -7,12 +7,14 @@
 #include <gmock/gmock.h>
 #include "API/TaskServiceClass.h"
 #include <iostream>
+#include "Memory_Model/RepositoriesFactory/TaskRepositoryFactory.h"
 
 class TestTaskService : public ::testing::Test {
 
  protected:
   virtual void SetUp() {
-    ts = std::make_unique<TaskServiceClass>(TaskServiceUtils::GetRepositoryFactory());
+    std::unique_ptr<RepositoriesFactory> factory = std::make_unique<TaskRepositoryFactory>();
+    ts = std::make_unique<TaskServiceClass>(std::move(factory));
   }
   std::unique_ptr<TaskService> ts;
 };


### PR DESCRIPTION
- Changed std::function TaskRepository Factory-method to Factory class. Changed implementation in the system.
- Renamed Persister Factory method.