### PR TITLE
Task repository utils

### DIFF
--- a/core/Repository/TaskRepositoryClass.cpp
+++ b/core/Repository/TaskRepositoryClass.cpp
@@ -9,7 +9,7 @@ TaskRepositoryClass::TaskRepositoryClass(std::unique_ptr<TaskView> view, std::un
  : taskView_(std::move(view)), taskStorage_(std::move(storage)){}
 
 AddTaskResult TaskRepositoryClass::AddTask(const TaskRepositoryDTO &task){
-  auto newTaskEntity = TaskRepositoryUtils::NewEntityFromDTO(task, taskIDGenerate_, std::nullopt);
+  auto newTaskEntity = task_repository_utils::NewEntityFromDTO(task, taskIDGenerate_, std::nullopt);
   if (!newTaskEntity.has_value()){
     return AddTaskResult::Failed(AddTaskResult::ErrorType::TASK_IS_DAMAGED);
   }
@@ -27,7 +27,7 @@ AddTaskResult TaskRepositoryClass::AddSubtask(const TaskID& rootTaskID, const Ta
     return AddTaskResult::Failed(AddTaskResult::ErrorType::NOT_FOUND_PARENT_TASK);
   }
 
-  auto newTaskEntity = TaskRepositoryUtils::NewEntityFromDTO(subtask, taskIDGenerate_, rootTaskID);
+  auto newTaskEntity = task_repository_utils::NewEntityFromDTO(subtask, taskIDGenerate_, rootTaskID);
   if (!newTaskEntity.has_value()){
     return AddTaskResult::Failed(AddTaskResult::ErrorType::NOT_FOUND_PARENT_TASK);
   }
@@ -99,7 +99,7 @@ std::optional<TaskRepositoryDTO> TaskRepositoryClass::GetTask(const TaskID& id) 
   if (!task.has_value()){
     return std::nullopt;
   }
-  return TaskRepositoryUtils::DTOFromEntity(*task.value());
+  return task_repository_utils::DTOFromEntity(*task.value());
 }
 std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetSubtask(const TaskID& id) const {
   auto task = taskStorage_->GetTask(id);
@@ -108,7 +108,7 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetSubtask(const TaskID& id)
     return subtasks;
   }
   for (const auto& subtask : task.value()->GetSubtasks()){
-    subtasks.push_back(TaskRepositoryUtils::DTOFromEntity(*subtask.second.lock()));
+    subtasks.push_back(task_repository_utils::DTOFromEntity(*subtask.second.lock()));
   }
   return subtasks;
 }
@@ -117,7 +117,7 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTasks() const{
   auto tasks = taskStorage_->GetTasks();
   std::vector<TaskRepositoryDTO> tasksDTO;
   for (const auto& task : tasks){
-    tasksDTO.push_back(TaskRepositoryUtils::DTOFromEntity(*task.second));
+    tasksDTO.push_back(task_repository_utils::DTOFromEntity(*task.second));
   }
   return tasksDTO;
 }
@@ -125,9 +125,9 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTasks() const{
 std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTodayTasks(bool byPriority) const {
   auto tasks = taskView_->GetTodayTasks();
   std::vector<TaskRepositoryDTO> tasksDTO;
-  TaskRepositoryUtils::VectorFromEntitiesToDTO(tasks, tasksDTO);
+  task_repository_utils::VectorFromEntitiesToDTO(tasks, tasksDTO);
   if (byPriority){
-    TaskRepositoryUtils::SortByPriority(tasksDTO);
+    task_repository_utils::SortByPriority(tasksDTO);
   }
   return tasksDTO;
 }
@@ -135,9 +135,9 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTodayTasks(bool byPriorit
 std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetWeekTasks(bool byPriority) const{
   auto tasks = taskView_->GetWeekTasks();
   std::vector<TaskRepositoryDTO> tasksDTO;
-  TaskRepositoryUtils::VectorFromEntitiesToDTO(tasks, tasksDTO);
+  task_repository_utils::VectorFromEntitiesToDTO(tasks, tasksDTO);
   if (byPriority){
-    TaskRepositoryUtils::SortByPriority(tasksDTO);
+    task_repository_utils::SortByPriority(tasksDTO);
   }
   return tasksDTO;
 }
@@ -145,9 +145,9 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetWeekTasks(bool byPriority
 std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTasksByLabel(const std::string& label, bool byPriority) const {
   auto tasks = taskView_->GetTasksByLabel(label);
   std::vector<TaskRepositoryDTO> tasksDTO;
-  TaskRepositoryUtils::VectorFromEntitiesToDTO(tasks, tasksDTO);
+  task_repository_utils::VectorFromEntitiesToDTO(tasks, tasksDTO);
   if (byPriority){
-    TaskRepositoryUtils::SortByPriority(tasksDTO);
+    task_repository_utils::SortByPriority(tasksDTO);
   }
   return tasksDTO;
 }
@@ -155,9 +155,9 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTasksByLabel(const std::s
 std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTasksByName(const std::string& name, bool byPriority) const {
   auto tasks = taskView_->GetTasksByName(name);
   std::vector<TaskRepositoryDTO> tasksDTO;
-  TaskRepositoryUtils::VectorFromEntitiesToDTO(tasks, tasksDTO);
+  task_repository_utils::VectorFromEntitiesToDTO(tasks, tasksDTO);
   if (byPriority){
-    TaskRepositoryUtils::SortByPriority(tasksDTO);
+    task_repository_utils::SortByPriority(tasksDTO);
   }
   return tasksDTO;
 }
@@ -165,7 +165,7 @@ std::vector<TaskRepositoryDTO> TaskRepositoryClass::GetTasksByPriority(const Pri
   auto tasks = taskView_->GetTasksByPriority(priority);
   std::vector<TaskRepositoryDTO> tasksDTO;
   for (const auto& task : tasks){
-    tasksDTO.push_back(TaskRepositoryUtils::DTOFromEntity(task));
+    tasksDTO.push_back(task_repository_utils::DTOFromEntity(task));
   }
   return tasksDTO;
 }

--- a/core/Repository/TaskRepositoryClass.h
+++ b/core/Repository/TaskRepositoryClass.h
@@ -42,11 +42,6 @@
   std::vector<TaskRepositoryDTO>      GetTasksByPriority(const Priority& priority) const override;
 
  private:
-   TaskRepositoryDTO                  DTOFromEntity(const TaskEntity& entity) const;
-   std::optional<TaskEntity>          EntityFromDTO(const TaskRepositoryDTO& dto, std::optional<TaskID> rootID);
-   void                               SortByPriority(std::vector<TaskRepositoryDTO>& tasks) const;
-
- private:
   std::unique_ptr<TaskView>           taskView_;
   std::unique_ptr<TaskStorage>        taskStorage_;
   TaskIDGenerate                      taskIDGenerate_;

--- a/core/Repository/Utils/TaskRepositoryUtils.cpp
+++ b/core/Repository/Utils/TaskRepositoryUtils.cpp
@@ -1,0 +1,40 @@
+//
+// Created by valeriisudakov on 19.10.20.
+//
+
+#include "TaskRepositoryUtils.h"
+
+TaskRepositoryDTO TaskRepositoryUtils::DTOFromEntity(const TaskEntity &entity) {
+  auto task = TaskRepositoryDTO::Create(entity.GetName(), entity.GetLabel(), entity.GetPriority(),
+                                        entity.GetDueDate(), entity.IsComplete(), entity.GetId(), entity.GetParentId());
+  assert(task.has_value());
+
+  return task.value();
+}
+
+std::optional<TaskEntity> TaskRepositoryUtils::NewEntityFromDTO(const TaskRepositoryDTO &dto, TaskIDGenerate& generator, std::optional<TaskID> rootID) {
+  auto newTask = Task::Create(dto.GetName(), dto.GetLabel(), dto.GetPriority(), dto.GetDate());
+  if (!newTask.has_value()){
+    return std::nullopt;
+  }
+  if (rootID.has_value()){
+    return TaskEntity(newTask.value(), generator.Generate(), rootID.value());
+  } else {
+    return TaskEntity(newTask.value(), generator.Generate());
+  }
+}
+
+void TaskRepositoryUtils::SortByPriority(std::vector<TaskRepositoryDTO> &tasks) {
+  std::sort(tasks.begin(), tasks.end(),
+            [](const TaskRepositoryDTO& first, const TaskRepositoryDTO& second) {
+              return first.GetPriority() < second.GetPriority();
+            }
+  );
+}
+
+void TaskRepositoryUtils::VectorFromEntitiesToDTO(const std::vector<TaskEntity>& entities,
+                                                           std::vector<TaskRepositoryDTO>& dto){
+  for (const auto& task : entities){
+    dto.push_back(TaskRepositoryUtils::DTOFromEntity(task));
+  }
+}

--- a/core/Repository/Utils/TaskRepositoryUtils.cpp
+++ b/core/Repository/Utils/TaskRepositoryUtils.cpp
@@ -4,7 +4,7 @@
 
 #include "TaskRepositoryUtils.h"
 
-TaskRepositoryDTO TaskRepositoryUtils::DTOFromEntity(const TaskEntity &entity) {
+TaskRepositoryDTO task_repository_utils::DTOFromEntity(const TaskEntity &entity) {
   auto task = TaskRepositoryDTO::Create(entity.GetName(), entity.GetLabel(), entity.GetPriority(),
                                         entity.GetDueDate(), entity.IsComplete(), entity.GetId(), entity.GetParentId());
   assert(task.has_value());
@@ -12,7 +12,7 @@ TaskRepositoryDTO TaskRepositoryUtils::DTOFromEntity(const TaskEntity &entity) {
   return task.value();
 }
 
-std::optional<TaskEntity> TaskRepositoryUtils::NewEntityFromDTO(const TaskRepositoryDTO &dto, TaskIDGenerate& generator, std::optional<TaskID> rootID) {
+std::optional<TaskEntity> task_repository_utils::NewEntityFromDTO(const TaskRepositoryDTO &dto, TaskIDGenerate& generator, std::optional<TaskID> rootID) {
   auto newTask = Task::Create(dto.GetName(), dto.GetLabel(), dto.GetPriority(), dto.GetDate());
   if (!newTask.has_value()){
     return std::nullopt;
@@ -24,7 +24,7 @@ std::optional<TaskEntity> TaskRepositoryUtils::NewEntityFromDTO(const TaskReposi
   }
 }
 
-void TaskRepositoryUtils::SortByPriority(std::vector<TaskRepositoryDTO> &tasks) {
+void task_repository_utils::SortByPriority(std::vector<TaskRepositoryDTO> &tasks) {
   std::sort(tasks.begin(), tasks.end(),
             [](const TaskRepositoryDTO& first, const TaskRepositoryDTO& second) {
               return first.GetPriority() < second.GetPriority();
@@ -32,9 +32,9 @@ void TaskRepositoryUtils::SortByPriority(std::vector<TaskRepositoryDTO> &tasks) 
   );
 }
 
-void TaskRepositoryUtils::VectorFromEntitiesToDTO(const std::vector<TaskEntity>& entities,
+void task_repository_utils::VectorFromEntitiesToDTO(const std::vector<TaskEntity>& entities,
                                                            std::vector<TaskRepositoryDTO>& dto){
   for (const auto& task : entities){
-    dto.push_back(TaskRepositoryUtils::DTOFromEntity(task));
+    dto.push_back(task_repository_utils::DTOFromEntity(task));
   }
 }

--- a/core/Repository/Utils/TaskRepositoryUtils.h
+++ b/core/Repository/Utils/TaskRepositoryUtils.h
@@ -8,7 +8,7 @@
 #include "Repository/Task/TaskEntity.h"
 #include "Repository/Task/ID/TaskIDGenerate.h"
 
-namespace TaskRepositoryUtils {
+namespace task_repository_utils {
 
   TaskRepositoryDTO                  DTOFromEntity(const TaskEntity& entity);
   void                               VectorFromEntitiesToDTO(const std::vector<TaskEntity>& entities,

--- a/core/Repository/Utils/TaskRepositoryUtils.h
+++ b/core/Repository/Utils/TaskRepositoryUtils.h
@@ -1,0 +1,21 @@
+//
+// Created by valeriisudakov on 19.10.20.
+//
+
+#ifndef TASKMANAGER_CORE_REPOSITORY_UTILS_TASKREPOSITORYUTILS_H_
+#define TASKMANAGER_CORE_REPOSITORY_UTILS_TASKREPOSITORYUTILS_H_
+#include "Repository/DTO/TaskRepositoryDTO.h"
+#include "Repository/Task/TaskEntity.h"
+#include "Repository/Task/ID/TaskIDGenerate.h"
+
+namespace TaskRepositoryUtils {
+
+  TaskRepositoryDTO                  DTOFromEntity(const TaskEntity& entity);
+  void                               VectorFromEntitiesToDTO(const std::vector<TaskEntity>& entities,
+                                                             std::vector<TaskRepositoryDTO>& dto);
+  std::optional<TaskEntity>          NewEntityFromDTO(const TaskRepositoryDTO& dto, TaskIDGenerate& generator,
+                                                      std::optional<TaskID> rootID);
+  void                               SortByPriority(std::vector<TaskRepositoryDTO>& tasks);
+};
+
+#endif //TASKMANAGER_CORE_REPOSITORY_UTILS_TASKREPOSITORYUTILS_H_

--- a/tests/core/TestTaskRepository.cpp
+++ b/tests/core/TestTaskRepository.cpp
@@ -65,3 +65,19 @@ TEST_F(TestTaskRepository, shouldntRemoveTask){
   TaskRepositoryClass tr(std::move(std::make_unique<TaskViewClass>()), std::move(std::make_unique<TaskStorageClass>()));
   ASSERT_FALSE(tr.RemoveTask(TaskID(421)));
 }
+
+TEST_F(TestTaskRepository, shouldSetComplete){
+  TaskRepositoryClass tr(std::move(std::make_unique<TaskViewClass>()), std::move(std::make_unique<TaskStorageClass>()));
+  std::optional<Task> task = Task::Create("task", "label", Priority::NONE, Date::GetCurrentTime());
+  tr.AddTask(ToDTO(task.value()));
+
+  auto uncompletedTask = tr.GetTask(TaskID(0));
+  ASSERT_FALSE(uncompletedTask.value().Complete());
+
+  ASSERT_FALSE(tr.SetTaskComplete(TaskID(412423512)));
+  ASSERT_TRUE(tr.SetTaskComplete(TaskID(0)));
+
+  auto completeTask = tr.GetTask(TaskID(0));
+  ASSERT_TRUE(completeTask.value().Complete());
+
+}

--- a/tests/core/TestTaskRepositoryUtils.cpp
+++ b/tests/core/TestTaskRepositoryUtils.cpp
@@ -8,7 +8,7 @@ class TestTaskRepositoryUtils : public ::testing::Test {
 TEST_F(TestTaskRepositoryUtils, shouldMakeDTOfromEntity){
   auto task = Task::Create("name", "label", Priority::NONE, Date::GetCurrentTime());
   auto entity = TaskEntity(task.value(), TaskID());
-  auto dto = TaskRepositoryUtils::DTOFromEntity(entity);
+  auto dto = task_repository_utils::DTOFromEntity(entity);
   ASSERT_EQ(dto.GetName(), entity.GetName());
   ASSERT_EQ(dto.GetLabel(), entity.GetLabel());
   ASSERT_EQ(dto.GetPriority(), entity.GetPriority());
@@ -18,7 +18,7 @@ TEST_F(TestTaskRepositoryUtils, shouldMakeDTOfromEntity){
 TEST_F(TestTaskRepositoryUtils, shouldMakeEntityFromDTO){
   TaskIDGenerate generate;
   auto dto = TaskRepositoryDTO::Create("root", "label", Priority::NONE, Date::GetCurrentTime());
-  auto rootEntity = TaskRepositoryUtils::NewEntityFromDTO(dto.value(), generate, std::nullopt);
+  auto rootEntity = task_repository_utils::NewEntityFromDTO(dto.value(), generate, std::nullopt);
   ASSERT_EQ(dto.value().GetName(), rootEntity.value().GetName());
   ASSERT_EQ(dto.value().GetLabel(), rootEntity.value().GetLabel());
   ASSERT_EQ(dto.value().GetPriority(), rootEntity.value().GetPriority());
@@ -26,7 +26,7 @@ TEST_F(TestTaskRepositoryUtils, shouldMakeEntityFromDTO){
 
 
   auto dto1 = TaskRepositoryDTO::Create("root", "label", Priority::NONE, Date::GetCurrentTime());
-  auto subEntity = TaskRepositoryUtils::NewEntityFromDTO(dto.value(), generate, rootEntity.value().GetId());
+  auto subEntity = task_repository_utils::NewEntityFromDTO(dto.value(), generate, rootEntity.value().GetId());
   ASSERT_EQ(dto1.value().GetName(), subEntity.value().GetName());
   ASSERT_EQ(dto1.value().GetLabel(), subEntity.value().GetLabel());
   ASSERT_EQ(dto1.value().GetPriority(), subEntity.value().GetPriority());
@@ -39,17 +39,17 @@ TEST_F(TestTaskRepositoryUtils, shouldSortByPriority) {
   std::vector<TaskRepositoryDTO> dto;
   auto task = Task::Create("1", "label", Priority::NONE, Date::GetCurrentTime());
   auto entity = TaskEntity(task.value(), TaskID());
-  dto.push_back(TaskRepositoryUtils::DTOFromEntity(entity));
+  dto.push_back(task_repository_utils::DTOFromEntity(entity));
 
   auto task1 = Task::Create("2", "label", Priority::FIRST, Date::GetCurrentTime());
   auto entity1 = TaskEntity(task1.value(), TaskID());
-  auto tempDTO1 = TaskRepositoryUtils::DTOFromEntity(entity1);
+  auto tempDTO1 = task_repository_utils::DTOFromEntity(entity1);
   dto.push_back(tempDTO1);
 
   ASSERT_EQ(dto[0].GetPriority(), Priority::NONE);
   ASSERT_EQ(dto[1].GetPriority(), Priority::FIRST);
 
-  TaskRepositoryUtils::SortByPriority(dto);
+  task_repository_utils::SortByPriority(dto);
 
   ASSERT_EQ(dto[0].GetPriority(), Priority::FIRST);
   ASSERT_EQ(dto[1].GetPriority(), Priority::NONE);

--- a/tests/core/TestTaskRepositoryUtils.cpp
+++ b/tests/core/TestTaskRepositoryUtils.cpp
@@ -1,0 +1,56 @@
+#include "gtest/gtest.h"
+#include "Repository/Utils/TaskRepositoryUtils.h"
+
+class TestTaskRepositoryUtils : public ::testing::Test {
+
+};
+
+TEST_F(TestTaskRepositoryUtils, shouldMakeDTOfromEntity){
+  auto task = Task::Create("name", "label", Priority::NONE, Date::GetCurrentTime());
+  auto entity = TaskEntity(task.value(), TaskID());
+  auto dto = TaskRepositoryUtils::DTOFromEntity(entity);
+  ASSERT_EQ(dto.GetName(), entity.GetName());
+  ASSERT_EQ(dto.GetLabel(), entity.GetLabel());
+  ASSERT_EQ(dto.GetPriority(), entity.GetPriority());
+  ASSERT_EQ(dto.GetDate().Get().day_number(), entity.GetDueDate().Get().day_number());
+}
+
+TEST_F(TestTaskRepositoryUtils, shouldMakeEntityFromDTO){
+  TaskIDGenerate generate;
+  auto dto = TaskRepositoryDTO::Create("root", "label", Priority::NONE, Date::GetCurrentTime());
+  auto rootEntity = TaskRepositoryUtils::NewEntityFromDTO(dto.value(), generate, std::nullopt);
+  ASSERT_EQ(dto.value().GetName(), rootEntity.value().GetName());
+  ASSERT_EQ(dto.value().GetLabel(), rootEntity.value().GetLabel());
+  ASSERT_EQ(dto.value().GetPriority(), rootEntity.value().GetPriority());
+  ASSERT_EQ(dto.value().GetDate().Get().day_number(), rootEntity.value().GetDueDate().Get().day_number());
+
+
+  auto dto1 = TaskRepositoryDTO::Create("root", "label", Priority::NONE, Date::GetCurrentTime());
+  auto subEntity = TaskRepositoryUtils::NewEntityFromDTO(dto.value(), generate, rootEntity.value().GetId());
+  ASSERT_EQ(dto1.value().GetName(), subEntity.value().GetName());
+  ASSERT_EQ(dto1.value().GetLabel(), subEntity.value().GetLabel());
+  ASSERT_EQ(dto1.value().GetPriority(), subEntity.value().GetPriority());
+  ASSERT_EQ(dto1.value().GetDate().Get().day_number(), subEntity.value().GetDueDate().Get().day_number());
+  ASSERT_EQ(subEntity.value().GetParentId(), rootEntity.value().GetId());
+}
+
+
+TEST_F(TestTaskRepositoryUtils, shouldSortByPriority) {
+  std::vector<TaskRepositoryDTO> dto;
+  auto task = Task::Create("1", "label", Priority::NONE, Date::GetCurrentTime());
+  auto entity = TaskEntity(task.value(), TaskID());
+  dto.push_back(TaskRepositoryUtils::DTOFromEntity(entity));
+
+  auto task1 = Task::Create("2", "label", Priority::FIRST, Date::GetCurrentTime());
+  auto entity1 = TaskEntity(task1.value(), TaskID());
+  auto tempDTO1 = TaskRepositoryUtils::DTOFromEntity(entity1);
+  dto.push_back(tempDTO1);
+
+  ASSERT_EQ(dto[0].GetPriority(), Priority::NONE);
+  ASSERT_EQ(dto[1].GetPriority(), Priority::FIRST);
+
+  TaskRepositoryUtils::SortByPriority(dto);
+
+  ASSERT_EQ(dto[0].GetPriority(), Priority::FIRST);
+  ASSERT_EQ(dto[1].GetPriority(), Priority::NONE);
+}


### PR DESCRIPTION
- Convert and sort functions have been moved from TaskRepository class to TaskRepositoryUtils namespace. This made these functions available for testing and reusable.
- Added tests for this.